### PR TITLE
fix bug in embarcadero::partial()

### DIFF
--- a/R/partials.R
+++ b/R/partials.R
@@ -89,10 +89,10 @@ partial <- function(model, x.vars=NULL, equal=TRUE, smooth=1,
       }
     }
     
-    pd <- pdbart(model, xind = x.vars, levs = lev, pl=FALSE)
+    pd <- pdbart(fitobj, xind = x.vars, levs = lev, pl=FALSE)
   } else {
     levq = c(0.5 - ciwidth/2, seq(0.1, 0.9, 0.1/smooth), 0.5 + ciwidth/2)
-    pd <- pdbart(model, xind = x.vars, levquants = levq, pl=FALSE)
+    pd <- pdbart(fitobj, xind = x.vars, levquants = levq, pl=FALSE)
   }
  
   


### PR DESCRIPTION
Current version of the function `partial` doesn't work with Random Intercept BART models. Checking the code of the function the step `pd <- pdbart(model, xind = x.vars, levs = lev, pl=FALSE)` use the model object (`bart`, `rbart`...) itself. However, using `rbart` as an input of the step return error: `x.train must be a matrix, data.frame, formula, fitted bart model, or dbartsSampler`. 

Changing the input object,  `fitobj` (created previously) for `model` object works properly for both, `bart` and `rbart` models.

I will check the same for other function (`spartials()`, etc) and make the PR then

